### PR TITLE
Update calendar-ui package, add localization settinsg if calendar plugin isn't installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "lodash": "4.17.20",
     "neverthrow": "3.0.0",
-    "obsidian-calendar-ui": "0.2.1",
+    "obsidian-calendar-ui": "0.3.0",
     "obsidian-daily-notes-interface": "0.5.1",
     "rrule": "npm:@tgrosinger/rrule",
     "svelte": "3.31.0"

--- a/src/localization.ts
+++ b/src/localization.ts
@@ -1,18 +1,20 @@
 import type { App } from 'obsidian';
 import { configureGlobalMomentLocale } from 'obsidian-calendar-ui';
-
 import type { ISettings } from 'src/settings';
 
-export function shouldConfigureGlobalMoment(app: App) {
+export const shouldConfigureGlobalMoment = (app: App): boolean => 
   // XXX: If the calendar plugin is installed, just use those settings.
   // Otherwise, we are responsible for configuring weekStart and localeOverride.
-  return !(<any>app).plugins.getPlugin('calendar')?._loaded;
-}
+   !(app as any).plugins.getPlugin('calendar')?._loaded
+;
 
-export function tryToConfigureGlobalMoment(app: App, settings: ISettings) {
+export const tryToConfigureGlobalMoment = (
+  app: App,
+  settings: ISettings,
+): void => {
   // XXX: If the calendar plugin is installed, just use those settings.
   // Otherwise, we are responsible for configuring weekStart and localeOverride.
   if (shouldConfigureGlobalMoment) {
     configureGlobalMomentLocale(settings.localeOverride, settings.weekStart);
   }
-}
+};

--- a/src/localization.ts
+++ b/src/localization.ts
@@ -1,0 +1,18 @@
+import type { App } from 'obsidian';
+import { configureGlobalMomentLocale } from 'obsidian-calendar-ui';
+
+import type { ISettings } from 'src/settings';
+
+export function shouldConfigureGlobalMoment(app: App) {
+  // XXX: If the calendar plugin is installed, just use those settings.
+  // Otherwise, we are responsible for configuring weekStart and localeOverride.
+  return !(<any>app).plugins.getPlugin('calendar')?._loaded;
+}
+
+export function tryToConfigureGlobalMoment(app: App, settings: ISettings) {
+  // XXX: If the calendar plugin is installed, just use those settings.
+  // Otherwise, we are responsible for configuring weekStart and localeOverride.
+  if (shouldConfigureGlobalMoment) {
+    configureGlobalMomentLocale(settings.localeOverride, settings.weekStart);
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,3 @@
-/* eslint-disable */
-import type moment from 'moment';
-import type { WeekSpec } from 'moment';
-/* eslint-enable */
-
 import {
   buyMeACoffee,
   checkboxIcon,
@@ -22,7 +17,7 @@ import { TaskView, TaskViewType } from './task-view';
 import TaskMove from './ui/TaskMove.svelte';
 import TaskRepeat from './ui/TaskRepeat.svelte';
 import { VaultIntermediate } from './vault';
-
+import type { default as MomentType, WeekSpec } from 'moment';
 import {
   addIcon,
   App,
@@ -45,7 +40,7 @@ import type { IWeekStartOption } from 'obsidian-calendar-ui';
 
 declare global {
   interface Window {
-    moment: typeof moment;
+    moment: typeof MomentType;
     _bundledLocaleWeekSpec: WeekSpec;
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,19 +1,7 @@
-import type { WeekSpec } from 'moment';
+/* eslint-disable */
 import type moment from 'moment';
-import {
-  addIcon,
-  App,
-  MarkdownPostProcessorContext,
-  MarkdownPreviewRenderer,
-  MarkdownView,
-  Modal,
-  Notice,
-  Plugin,
-  PluginSettingTab,
-  Setting,
-  TFile,
-} from 'obsidian';
-import type { IWeekStartOption } from 'obsidian-calendar-ui';
+import type { WeekSpec } from 'moment';
+/* eslint-enable */
 
 import {
   buyMeACoffee,
@@ -34,6 +22,21 @@ import { TaskView, TaskViewType } from './task-view';
 import TaskMove from './ui/TaskMove.svelte';
 import TaskRepeat from './ui/TaskRepeat.svelte';
 import { VaultIntermediate } from './vault';
+
+import {
+  addIcon,
+  App,
+  MarkdownPostProcessorContext,
+  MarkdownPreviewRenderer,
+  MarkdownView,
+  Modal,
+  Notice,
+  Plugin,
+  PluginSettingTab,
+  Setting,
+  TFile,
+} from 'obsidian';
+import type { IWeekStartOption } from 'obsidian-calendar-ui';
 
 // TODO: Can I use a webworker to perform a scan of files in the vault for
 // tasks that would otherwise be missed and not have a repetition created?
@@ -369,13 +372,11 @@ class SettingsTab extends PluginSettingTab {
       });
 
     if (shouldConfigureGlobalMoment(this.app)) {
-      const { moment } = window;
-
       const sysLocale = navigator.language?.toLowerCase();
 
-      const localizedWeekdays = moment.weekdays();
+      const localizedWeekdays = window.moment.weekdays();
       const localeWeekStartNum = window._bundledLocaleWeekSpec.dow;
-      const localeWeekStart = moment.weekdays()[localeWeekStartNum];
+      const localeWeekStart = window.moment.weekdays()[localeWeekStartNum];
       const weekdays = [
         'sunday',
         'monday',
@@ -411,7 +412,7 @@ class SettingsTab extends PluginSettingTab {
         )
         .addDropdown((dropdown) => {
           dropdown.addOption('system-default', `Same as system (${sysLocale})`);
-          moment.locales().forEach((locale) => {
+          window.moment.locales().forEach((locale) => {
             dropdown.addOption(locale, locale);
           });
           dropdown.setValue(this.plugin.settings.localeOverride);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,8 +1,14 @@
+import type { ILocaleOverride, IWeekStartOption } from 'obsidian-calendar-ui';
+
 export interface ISettings {
   tasksHeader: string;
   blankLineAfterHeader: boolean;
   aliasLinks: boolean;
   enableTaskView: boolean;
+
+  // Calendar view
+  localeOverride: ILocaleOverride;
+  weekStart: IWeekStartOption;
 }
 
 const defaultSettings: ISettings = {
@@ -10,6 +16,9 @@ const defaultSettings: ISettings = {
   blankLineAfterHeader: true,
   aliasLinks: true,
   enableTaskView: false,
+
+  localeOverride: 'system-default',
+  weekStart: 'locale',
 };
 
 export const settingsWithDefaults = (

--- a/src/ui/TaskMove.svelte
+++ b/src/ui/TaskMove.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-  import type { TaskLine } from 'src/task-line';
   import type { Moment } from 'moment';
   import { Calendar } from 'obsidian-calendar-ui';
+
+  import type { TaskLine } from 'src/task-line';
 
   // Creation Parameters
   export let task: TaskLine;
@@ -22,7 +23,12 @@
 
 <p>Select a day for the task to be moved to:</p>
 
-<Calendar {onClickDay} {today} />
+<Calendar
+  {onClickDay}
+  {today}
+  showWeekNums={false}
+  localeData={today.localeData()}
+/>
 
 <label>
   <input type="checkbox" bind:checked={createLinks} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -3560,10 +3560,10 @@ object.values@^1.1.1:
     es-abstract "^1.18.0-next.1"
     has "^1.0.3"
 
-obsidian-calendar-ui@0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/obsidian-calendar-ui/-/obsidian-calendar-ui-0.2.1.tgz#f0645add7e6ef71f3a589a375e411a67ab6b8b3d"
-  integrity sha512-2ZVbJW50VT1cXnQvIIZCIs17uKPaSWCUIlLOCi2e7Ylh8fPyAU90TkCVJuDOi5wVFRS8YzIseBV2osXo92h6sQ==
+obsidian-calendar-ui@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/obsidian-calendar-ui/-/obsidian-calendar-ui-0.3.0.tgz#3c3af76a6995d2b17e7185d19b1fdf180e9106ce"
+  integrity sha512-C07BIq04m+jKF0foZOB6dzxRXHRDFJs2vDYEH97qV2iKC00TOYHwwFg8PgRNQARs+TZGRGI3Tn05xIzy9c7Jdg==
   dependencies:
     obsidian-daily-notes-interface "0.5.1"
     svelte "3.31.0"


### PR DESCRIPTION
My very basic/dumb approach to localization here is: 

> if the calendar plugin is installed, use those settings. If not, show localization settings within slated.

It's far from optimal but it is at least functional. Open to ideas for a better approach!