### PR TITLE
Add case for special moment settings

### DIFF
--- a/src/vault.ts
+++ b/src/vault.ts
@@ -41,7 +41,8 @@ export class VaultIntermediate {
   public findMomentForDailyNote = (file: TFile): Moment | undefined => {
     const { format } = getDailyNoteSettings();
     const date = window.moment(file.basename, format, true);
-    return date.isValid() ? date : null;
+    const dateFullPath = window.moment(file.path.split(".md")[0], format, true)
+    return date.isValid() ? date : dateFullPath.isValid() ? dateFullPath : null;
   };
 
   public fileNameForMoment = (date: Moment): string =>


### PR DESCRIPTION
My daily note format `[6. Productivity]/[Journal]/YYYY/MM - MMMM/YYYY-MM-DD` while valid in Moment and in Obsidian settings created issue with repeated tasks because the current way was just looking for the final end (YYYY-MM-DD) so it was never valid.  

I switched it to look for both case and it doesn't seems to have created problems so far in my use so I'm sending it if you want to integrate for possibly others who have the same sort of settings.