### PR TITLE
Fix repeating tasks being offset by one

### DIFF
--- a/src/task-line.ts
+++ b/src/task-line.ts
@@ -147,7 +147,7 @@ export class TaskLine {
 
     const currentNoteDate = this.vault.findMomentForDailyNote(this.file);
     const nextDate = window
-      .moment(
+      .moment.utc(
         this.repeater.asRRule().after(currentNoteDate.endOf('day').toDate()),
       )
       .startOf('day');


### PR DESCRIPTION
This fixes the bug where repeating tasks get created for the day before they should be.